### PR TITLE
Add nil alias type

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-redis/redis"
 )
 
+var RedisNil = redis.Nil
+
 // Redis backend struct
 type RedisCache struct {
 	conn *redis.Client

--- a/redis_test.go
+++ b/redis_test.go
@@ -50,7 +50,7 @@ func TestRedisCacheSetCacheWithItem(t *testing.T) {
 	item := rc.NewItem("child", 1).Value("value")
 	err := c.Set(item)
 	assert.NoError(t, err)
-	v, err := c.Get("child1")
+	v, err := c.Get("child_1")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("value"), v)
 }


### PR DESCRIPTION
This PR adds `Nil` type of `go-redis`. You can use nil of redis result without using that package.