### PR TITLE
use unlink command on deleting cache

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -168,7 +168,7 @@ func (r *RedisCache) Del(items ...interface{}) error {
 	}
 
 	debug(r.w, fmt.Sprintf("[DEL] delete relevant caches %q\n", deleteKeys))
-	return r.conn.Del(deleteKeys...).Err()
+	return r.conn.Unlink(deleteKeys...).Err()
 }
 
 // Resolve and factory of relevant cahce keys.


### PR DESCRIPTION
Use `UNLINK` command for multiple cache deletion.

Note that UNLINK command only can use Redis engine v4 or later.