### PR TITLE
Replace keys with scan

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -234,15 +234,14 @@ func (r *RedisCache) factoryRelevantKeysWithAsterisk(key string) []string {
 			debug(r.w, fmt.Sprintf("failed to scan keys for %s, %s\n", key, err.Error()))
 			return relevantKeys
 		}
-		cursor = c
-
 		for _, k := range keys {
 			ks := r.factoryRelevantKeys(k)
 			relevantKeys = append(relevantKeys, ks...)
 		}
-		if cursor == 0 {
+		if c == 0 {
 			break
 		}
+		cursor = c
 	}
 	debug(r.w, fmt.Sprintf("[REL-ASTERISK] %s is relevant to %q\n", key, relevantKeys))
 	return relevantKeys


### PR DESCRIPTION
According to the redis document, it's not recommendable to use `KEYS` command.
So I replaced `Keys()` with `Scan()` in `factoryRelevantKeysWithAsterisk` method to improve performance.

https://redis.io/commands/keys
> Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using SCAN or sets.