### PR TITLE
specify scan count by option

### DIFF
--- a/option.go
+++ b/option.go
@@ -13,6 +13,7 @@ const (
 	//optionNameSplitBufferSize = "split_buffer_size"
 	optionNameSkipTLSVerify = "skip_tls_verify"
 	optionNameDebugWriter   = "debug_log"
+	optionNameScanCount     = "scan_count"
 )
 
 // func WithSplitBufferSize(size int64) option {
@@ -33,5 +34,12 @@ func WithDebugWriter(w io.Writer) option {
 	return option{
 		name:  optionNameDebugWriter,
 		value: w,
+	}
+}
+
+func WithScanCount(count int64) option {
+	return option{
+		name:  optionNameScanCount,
+		value: count,
 	}
 }


### PR DESCRIPTION
In #6 , I replaced `KEYS` command with `SCAN` command.
At that time, I fixed the value for SCAN command amiss.

The appropriate count values depends on the situation such as redis performance or number of keys.
So I added scan count option and users can specify it.